### PR TITLE
SRE-4678: add trace id to panics + allow service to crash

### DIFF
--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -3,4 +3,4 @@ name: kube-hpa-scale-to-zero
 description: https://github.com/SPSCommerce/kube-hpa-scale-to-zero
 type: application
 version: 0.8.0
-appVersion: "0.5.4"
+appVersion: "0.6.0"


### PR DESCRIPTION
it looks the service got locked up after this panic

```
"PANIC 'duplicate metrics collector registration attempted' occured at goroutine 189741 [running]:
runtime/debug.Stack()
	/usr/local/go/src/runtime/debug/stack.go:24 +0x65
github.com/SPSCommerce/kube-hpa-scale-to-zero/internal.MonitorHpa.func1()
	/sources/internal/monitor.go:343 +0x86
panic({0x17dba40, 0xc000022320})
	/usr/local/go/src/runtime/panic.go:884 +0x212
github.com/prometheus/client_golang/prometheus.(*Registry).MustRegister(0x19649ba?, {0xc0001c5040?, 0x1, 0x0?})
	/go/pkg/mod/github.com/prometheus/client_golang@v1.14.0/prometheus/registry.go:406 +0x7f
github.com/prometheus/client_golang/prometheus/promauto.Factory.NewCounter({{0x1bba938?, 0xc000040a50?}}, {{0x19649ba, 0xd}, {0x0, 0x0}, {0x195e2cd, 0x6}, {0x0, 0x0}, ...})
	/go/pkg/mod/github.com/prometheus/client_golang@v1.14.0/prometheus/promauto/auto.go:265 +0xfd
github.com/prometheus/client_golang/prometheus/promauto.NewCounter(...)
	/go/pkg/mod/github.com/prometheus/client_golang@v1.14.0/prometheus/promauto/auto.go:168
github.com/SPSCommerce/kube-hpa-scale-to-zero/internal.MetricsContext.RegisterNewHpa({{0x19649ba, 0xd}, {0x1bcdec0, 0xc000140d80}, {0x1bc9c78, 0xc00012a360}, 0xc000115b90, 0xc000115bc0}, {0xc000766450, 0x24}, ...)
	/sources/internal/metrics.go:50 +0x245
github.com/SPSCommerce/kube-hpa-scale-to-zero/internal.MonitorHpa({0x1bc7310, 0xc000140dc0}, 0xc000dca900, 0xc000126040, 0xc00048bfd0?, {0x1bb8778, 0xc000140d00}, {0x1bafa20, 0xc00011e0e0}, {{0x19649ba, ...}, ...}, ...)
	/sources/internal/monitor.go:347 +0x219
created by github.com/SPSCommerce/kube-hpa-scale-to-zero/internal.SetupHpaInformer.func2
	/sources/internal/monitor.go:404 +0x3d9
```

I'm still investigating the root cause of this, but this update will allow pod to restart properly