### PR TITLE
fix scale to zero clusterrole perms

### DIFF
--- a/helm-chart/templates/rbac.yaml
+++ b/helm-chart/templates/rbac.yaml
@@ -18,7 +18,7 @@ rules:
     verbs: ["get"]
   - apiGroups: ["external.metrics.k8s.io"]
     resources: ["*"]
-    verbs: ["get", "list",]
+    verbs: ["get", "list"]
 
 
 ---

--- a/helm-chart/templates/rbac.yaml
+++ b/helm-chart/templates/rbac.yaml
@@ -16,6 +16,9 @@ rules:
   - apiGroups: ["custom.metrics.k8s.io"]
     resources: ["*"]
     verbs: ["get"]
+  - apiGroups: ["external.metrics.k8s.io"]
+    resources: ["*"]
+    verbs: ["get", "list",]
 
 
 ---


### PR DESCRIPTION
when using scale to zero with cloudwatch metrics, fails to list external metrics, adding perms to clusterrole

`{"level":"error","ts":1705091018.7911105,"logger":"Root.Informer.HpaMonitor","msg":"not able to process HPA: at least one metric is in invalid state:unable to request metric: unable list metrics: aws_sqs_approximate_number_of_messages_visible_sum.external.metrics.k8s.io is forbidden ││ : User \"system:serviceaccount:kube-system:hpa-scale-to-zero\" cannot list resource \"aws_sqs_approximate_number_of_messages_visible_sum\" in API group \"external.metrics.k8s.io\" in the namespace \"prod-analytics-op\"","uid":"57ae5ed6-f9c8-4e2f-a8f1-518fd1235d44","namespace":"prod- ││ analytics-op","name":"op-document-parser"}  `

slack thread: https://spscommerce.slack.com/archives/CEL3X47U2/p1705087847859239
prod alert: https://spscommerce.slack.com/archives/C01RZLZGDJM/p1705091719252699
pagerduty: https://spscommerce.pagerduty.com/incidents/Q2Z6F77AL7KI5O