### PR TITLE
bump app version

### DIFF
--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -3,4 +3,4 @@ name: kube-hpa-scale-to-zero
 description: https://github.com/SPSCommerce/kube-hpa-scale-to-zero
 type: application
 version: 0.8.3
-appVersion: "0.6.1"
+appVersion: "0.6.2"


### PR DESCRIPTION
includes https://github.com/SPSCommerce/kube-hpa-scale-to-zero/pull/16