### PR TITLE
Index out of range with length 0

### DIFF
--- a/src/internal/monitor.go
+++ b/src/internal/monitor.go
@@ -3,6 +3,10 @@ package internal
 import (
 	"context"
 	"fmt"
+	"runtime/debug"
+	"sync"
+	"time"
+
 	"go.uber.org/zap"
 	autoscaling "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,9 +19,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/metrics/pkg/client/custom_metrics"
 	"k8s.io/metrics/pkg/client/external_metrics"
-	"runtime/debug"
-	"sync"
-	"time"
 )
 
 func UnmarshalCurrentMetrics(hpa *autoscaling.HorizontalPodAutoscaler) (*[]autoscaling.MetricStatus, error) {
@@ -108,6 +109,10 @@ func RequestIfExternalMetricValueIsZero(client external_metrics.ExternalMetricsC
 
 	if err != nil {
 		return false, fmt.Errorf("unable list metrics: %s", err)
+	}
+
+	if len(metrics.Items) == 0 {
+		return false, fmt.Errorf("no external metrics found")
 	}
 
 	if len(metrics.Items) > 1 {


### PR DESCRIPTION
This repo doesn't have any tests, but this should address this error:
```
{"level":"info","ts":1712932327.9584122,"logger":"Root.Informer.HpaMonitor","msg":"Should be scaled up to 1","uid":"d488c05c-23dd-4841-b59f-5f1ea10a44fd","namespace":"integrpanic: runtime error: index out of range [0] with length 0
goroutine 689 [running]:                                                                                                                                                     github.com/SPSCommerce/kube-hpa-scale-to-zero/internal.RequestIfExternalMetricValueIsZero({0x1bc36c0, 0xc00068f090}, {0xc00070bf80, 0x1e}, 0xc000278640)                         /sources/internal/monitor.go:117 +0x227                                                                                                                                  github.com/SPSCommerce/kube-hpa-scale-to-zero/internal.RequestIfMetricValueIsZero({0x1bcc418?, 0xc0006af480?}, {0x1bc36c0?, 0xc00068f090?}, 0xc00007b3a0?, {0xc00070bf80?, 0x    /sources/internal/monitor.go:129 +0x9d
github.com/SPSCommerce/kube-hpa-scale-to-zero/internal.RequestMetricValuesFromSpec.func1(0xc0008ce450?, 0x0, 0xc0003b7170, 0xc0006f8c00?)                                        /sources/internal/monitor.go:169 +0xa9                                                                                                                                   created by github.com/SPSCommerce/kube-hpa-scale-to-zero/internal.RequestMetricValuesFromSpec
    /sources/internal/monitor.go:166 +0x3b8
```

About to hop into meeting. Also the editor automatically formatted the imports