### PR TITLE
rethink how default alerts should be used

### DIFF
--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: kube-hpa-scale-to-zero
 description: https://github.com/SPSCommerce/kube-hpa-scale-to-zero
 type: application
-version: 0.9.0
+version: 0.10.0
 appVersion: "0.6.3"

--- a/helm-chart/templates/prometheus.yaml
+++ b/helm-chart/templates/prometheus.yaml
@@ -21,7 +21,7 @@ spec:
       {{- include "kube-hpa-scale-to-zero.selectorLabels" . | nindent 6 }}
       app: {{ include "kube-hpa-scale-to-zero.fullname" . }}
 
-{{ if or .Values.prometheus.alerts.panics.useDefault .Values.prometheus.alerts.metricErrors.useDefault .Values.prometheus.alerts.scalingErrors.useDefault }}
+{{ if or .Values.prometheus.useDefault }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
@@ -32,65 +32,28 @@ metadata:
     prometheus: {{ .Values.prometheus.selector }}
 spec:
   groups:
-    {{ if .Values.prometheus.alerts.panics.useDefault }}
-    - name: ScaleToZeroPanic
+    {{ range .Values.prometheus.alertGroups }}
+    - name: {{ .name }}
       rules:
-        - alert: ScaleToZeroPanic
-          expr: |-
-            delta(scale_to_zero_panics{service="kube-hpa-scale-to-zero"}[2m])>0
-          for: {{ .Values.prometheus.alerts.panics.for }}
+        {{ range .alerts }}
+        - alert: {{.name}}
+          expr: {{ .expression }}
+          for: {{ .for }}
           labels:
-            {{ if .Values.prometheus.alerts.labels }}
-            {{- toYaml .Values.prometheus.alerts.labels | nindent 12 }}
+            {{ if $.Values.prometheus.labels }}
+            {{- toYaml $.Values.prometheus.labels | nindent 12 }}
             {{ end }}
-            {{ if .Values.prometheus.alerts.panics.labels }}
-            {{- toYaml .Values.prometheus.alerts.labels | nindent 12 }}
+            {{ if .additionalLabels }}
+            {{- toYaml .additionalLabels | nindent 12 }}
             {{ end }}
-            severity: {{ .Values.prometheus.alerts.panics.severity }}
           annotations:
-            summary: Scale-to-zero is unable to scale HPA target
-            description: {{ .Values.prometheus.alerts.panics.description | toYaml }}
-    {{ end }}
-    
-    {{ if .Values.prometheus.alerts.metricErrors.useDefault }}
-    - name: ScaleToZeroMetricError
-      rules:
-        - alert: ScaleToZeroControllerUnableToDetermineIfScalingRequired
-          expr: |-
-            delta(scale_to_zero_errors{service="kube-hpa-scale-to-zero", type="metric"}[2m])>0
-          for: {{ .Values.prometheus.alerts.metricErrors.for }}
-          labels:
-            {{ if .Values.prometheus.alerts.labels }}
-            {{- toYaml .Values.prometheus.alerts.labels | nindent 12 }}
+            {{ if $.Values.prometheus.annotations }}
+            {{- toYaml $.Values.prometheus.annotations | nindent 12 }}
             {{ end }}
-            {{ if .Values.prometheus.alerts.metricErrors.labels }}
-            {{- toYaml .Values.prometheus.alerts.labels | nindent 12 }}
+            {{ if .additionalAnnotations }}
+            {{- toYaml .additionalAnnotations | nindent 12 }}
             {{ end }}            
-            severity: {{ .Values.prometheus.alerts.metricErrors.severity }}
-          annotations:
-            summary: Scale-to-zero is unable to scale HPA target
-            description: {{ .Values.prometheus.alerts.metricErrors.description | toYaml }}
+        {{ end}}
     {{ end }}
-    
-    {{ if .Values.prometheus.alerts.scalingErrors.useDefault }}
-    - name: ScaleToZeroScalingError
-      rules:
-        - alert: ScaleToZeroControllerUnableToScaleDeployment
-          expr: |-
-            delta(scale_to_zero_errors{service="kube-hpa-scale-to-zero", type="scaling"}[2m])>0
-          for: {{ .Values.prometheus.alerts.scalingErrors.for }}
-          labels:
-            {{ if .Values.prometheus.alerts.labels }}
-            {{- toYaml .Values.prometheus.alerts.labels | nindent 12 }}
-            {{ end }}
-            {{ if .Values.prometheus.alerts.scalingErrors.labels }}
-            {{- toYaml .Values.prometheus.alerts.labels | nindent 12 }}
-            {{ end }}              
-            severity: {{ .Values.prometheus.alerts.scalingErrors.severity }}
-          annotations:
-            summary: Scale-to-zero is unable to scale HPA target
-            description: {{ .Values.prometheus.alerts.scalingErrors.description | toYaml }}
-    {{ end }}
-
 {{ end }}
 {{ end }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -24,25 +24,42 @@ grafana:
 prometheus:
   useDefault: true
   selector: cluster-prometheus
-  alerts:
-    labels: {}
-    panics:
-      useDefault: true
-      severity: critical
-      description: Unable to proceed with HPA because of panic.
-      for: 1m
-      labels: {}
-    metricErrors:
-      useDefault: true
-      severity: warning
-      description: Unable to process one of HPA metrics.
-      for: 3m
-      labels: {}
-    scalingErrors:
-      useDefault: true
-      severity: critical
-      description: HPA target should be scaled, but error occurred.
-      for: 1m
-      labels: {}
-
+  labels: {}
+  annotations: {}
+  alertGroups:  
+    - name: ScaleToZeroPanic
+      alerts:
+        - name: ScaleToZeroPanic
+          for: 1m
+          additionalLabels: 
+            severity: critical
+          additionalAnnotations: 
+            summary: scale-to-zero paniced 
+            description: panic occured
+          expression: |-
+            delta(scale_to_zero_panics{service="kube-hpa-scale-to-zero"}[2m])>0
+    - name: ScaleToZeroMetricError
+      alerts:
+        - name: ScaleToZeroMetricError
+          useDefault: true
+          for: 3m
+          additionalLabels: 
+            severity: warning
+          additionalAnnotations: 
+            summary: scale-to-zero unable to determine if scaling is required
+            description: Unable to process one of HPA metrics        
+          expression: |- 
+            delta(scale_to_zero_errors{service="kube-hpa-scale-to-zero", type="metric"}[2m])>0"
+    - name: ScaleToZeroScalingError
+      alerts:
+        - name: ScaleToZeroScalingError
+          useDefault: true
+          for: 1m
+          additionalLabels: 
+            severity: critical
+          additionalAnnotations: 
+            summary: scale-to-zero unable to scale 
+            description: HPA target should be scaled, but error occurred         
+          expression: |- 
+            delta(scale_to_zero_errors{service="kube-hpa-scale-to-zero", type="scaling"}[2m])>0"      
 


### PR DESCRIPTION
I highly doubt that anyone will try to mix custom and default alerts because in this case it's just simpler to have everything in one place. With the current approach, it will be possible to reuse this chart but use your own alerts without the need to configure a separate local chart just for custom alerts