### PR TITLE
correctly handle asterisks in `expr`

### DIFF
--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: kube-hpa-scale-to-zero
 description: https://github.com/SPSCommerce/kube-hpa-scale-to-zero
 type: application
-version: 0.10.1
+version: 0.10.2
 appVersion: "0.6.4"

--- a/helm-chart/templates/prometheus.yaml
+++ b/helm-chart/templates/prometheus.yaml
@@ -34,7 +34,7 @@ spec:
       rules:
         {{ range $alert := $alertGroup.alerts }}
         - alert: {{$alert.name}}
-          expr: {{ $alert.expression }}
+          expr: {{ $alert.expression | quote }}
           for: {{ $alert.for }}
           labels:
             {{- if $.Values.prometheus.labels }}


### PR DESCRIPTION
right now 
```
prometheus:
  alertGroups:
    - name: Test
      alerts:
        - name: Test
          for: 1m
          expression: |-
            something
              * something
```
causes `Error: YAML parse error on kube-hpa-scale-to-zero/templates/prometheus.yaml: error converting YAML to JSON: yaml: line 20: did not find expected alphabetic or numeric character`
