### PR TITLE
actualize demo app example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -55,9 +55,5 @@ kubectl apply -f metric-generator.yml -n integration-demo
 ```
 to have multiple deployments with multiple random metrics bouncing between 0 and 1
 
-> **Note**\
-> This example uses `spscommerce.com/scaleToZero=demo` instead of the real `spscommerce.com/scaleToZero=true`
-> This will allow you to test your local version without affecting anything else
-
 Now you can run service locally to scale services in a real kube cluster:
-`go run ./cmd --kube-config "<path to your kube config>" --write-plain-logs --hpa-selector "spscommerce.com/scaleToZero=demo"`
+`go run ./cmd --kube-config "<path to your kube config>" --write-plain-logs --hpa-selector "spscommerce.com/scaleToZero=true"`

--- a/demo/app.yml
+++ b/demo/app.yml
@@ -53,13 +53,13 @@ spec:
       name: http
       targetPort: 80
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: scale-to-zero-demo-hpa
   namespace: integration-demo
   labels:
-    spscommerce.com/scaleToZero: "demo"
+    spscommerce.com/scaleToZero: "true"
 spec:
   behavior:
     scaleUp:


### PR DESCRIPTION
`autoscaling/v2` is available since `v1.23`, and `autoscaling/v2beta2` is no longer available since `v1.26`