### PR TITLE
die if custom metrics api is not discoverable in cluster

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -72,7 +72,7 @@ func main() {
 
 	config, err := clientcmd.BuildConfigFromFlags("", runtimeConfig.KubeConfigPath)
 	if err != nil {
-		logger.Error(err, "Unable to create kubernetes config")
+		logger.Error(err, "unable to create kubernetes config")
 		os.Exit(1)
 	}
 
@@ -82,11 +82,18 @@ func main() {
 		time.Second)
 
 	if err != nil {
-		logger.Error(err, "Unable to create kubernetes discovery client")
+		logger.Error(err, "unable to create kubernetes discovery client")
+		os.Exit(1)
 	}
 
 	restMapper := restmapper.NewDeferredDiscoveryRESTMapper(discoveryClient)
 
+	apiGetter := custom_metrics.NewAvailableAPIsGetter(discoveryClient)
+	_, err = apiGetter.PreferredVersion()
+	if err != nil {
+		logger.Error(err, "unable to discover custom metrics api")
+		os.Exit(1)
+	}
 	customMetricsClient := custom_metrics.NewForConfig(config, restMapper, custom_metrics.NewAvailableAPIsGetter(discoveryClient))
 
 	externalMetricsClient := external_metrics.NewForConfigOrDie(config)

--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -3,4 +3,4 @@ name: kube-hpa-scale-to-zero
 description: https://github.com/SPSCommerce/kube-hpa-scale-to-zero
 type: application
 version: 0.10.4
-appVersion: "0.8.4"
+appVersion: "0.9.0"


### PR DESCRIPTION
having cutom metrics api unavailable during discovery phase means that we will have nothing stored in our cache. in turn, this also means that all attempts to use those metrics later will also fail (i.e this affects "from zero" scaling)

"from zero" scaling is treated to be more important comparing to "to zero" scaling, so it makes sense to do this discovery early and fail if there is no custom metrics API available. this won't solve all possible problem, but should be enough to prevent problem when both scale-to-zero and prometheus-adapter (for example) where restarted at the same time. at least, "scale-to-zero is stuck in crashloop" is obvious signal that something is wrong in this cluster (and this is not related to the typo in metric name)