### PR TITLE
fix: improve error handling when there is no metric type

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -24,8 +24,8 @@ func ReportNotSupported(namespace string, hpaName string) {
 	errorsMetric.WithLabelValues(namespace, hpaName, "not_supported").Inc()
 }
 
-func ReportBadHpaState(namespace string, volumeType string) {
-	errorsMetric.WithLabelValues(namespace, volumeType, "hpa_state").Inc()
+func ReportBadHpaState(namespace string, hpaName string) {
+	errorsMetric.WithLabelValues(namespace, hpaName, "hpa_state").Inc()
 }
 func ReportCustomMetricError(namespace string, volumeType string) {
 	errorsMetric.WithLabelValues(namespace, volumeType, "custom_metric").Inc()


### PR DESCRIPTION
after migration to kube 1.29 we started to see sporadic `NotSupported` errors with `not supported metric type \"\"` text

this PR will not fix the root cause of those errors, but rather fix how we treat/classify them 