### PR TITLE
fix: default "<tag>" prevents app version from being used as image tag

### DIFF
--- a/deployment/helm-chart/values.yaml
+++ b/deployment/helm-chart/values.yaml
@@ -7,8 +7,8 @@ app:
   port: 9000
 
 pod:
-  repository: "<path to your OCI repository>"
-  version: "<tag>"
+  repository: ""
+  version: ""
   resources:
     limits:
       cpu: 100m


### PR DESCRIPTION
it doesn't work well with [this](https://github.com/SPSCommerce/kube-hpa-scale-to-zero/pull/57) change