### PR TITLE
update to golang 1.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.22.0
+FROM golang:1.23.0
 COPY . /sources
 WORKDIR /sources
 RUN go build -ldflags "-s" -o run ./cmd
 
 
-FROM golang:1.22.0
+FROM golang:1.23.0
 COPY --from=0 /sources/run /app/run
 WORKDIR /app
 ENTRYPOINT ["/app/run"]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/SPSCommerce/kube-hpa-scale-to-zero
 
-go 1.22.0
+go 1.23.0
+
 toolchain go1.23.4
 
 require (


### PR DESCRIPTION
the most recent [dependabot update](https://github.com/SPSCommerce/kube-hpa-scale-to-zero/pull/65) requires golang 1.23 to compile because of `k8s.io/apimachinery@v0.32.0` dependency 