### PR TITLE
chore: prepare dockerfile for multi-arch builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
-FROM golang:1.24.1
+FROM --platform=$BUILDPLATFORM golang:1.24.1 AS builder
 COPY . /sources
 WORKDIR /sources
-RUN go build -ldflags "-s" -o run ./cmd
 
+ARG TARGETARCH
 
-FROM golang:1.24.1
-COPY --from=0 /sources/run /app/run
+RUN GOOS=linux GOARCH=$TARGETARCH go build -ldflags "-s" -o run ./cmd
+
+FROM --platform=$TARGETPLATFORM golang:1.24.1
+COPY --from=builder /sources/run /app/run
 WORKDIR /app
 ENTRYPOINT ["/app/run"]
 CMD ["--hpa-selector", "spscommerce.com/scaleToZero=true", "--port", "8080"]


### PR DESCRIPTION
## Enable Multi-Architecture Docker Builds
Updated Dockerfile to support both AMD64 and ARM64 architectures, allowing native execution on Intel/AMD and ARM-based systems (AWS Graviton, Apple Silicon). This improves performance and enables cost savings with ARM instances.
Changes:

Added platform-specific build flags
Implemented cross-compilation support
Maintained backward compatibility

Build with: `docker buildx build --platform linux/amd64,linux/arm64 -t image:tag --push .`