### PR TITLE
fix deprecation warning in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG TARGETARCH
 
 RUN GOOS=linux GOARCH=$TARGETARCH go build -ldflags "-s" -o run ./cmd
 
-FROM --platform=$TARGETPLATFORM golang:1.25
+FROM golang:1.25
 COPY --from=builder /sources/run /app/run
 WORKDIR /app
 ENTRYPOINT ["/app/run"]


### PR DESCRIPTION
we don't need this anymore:

```
 1 warning found (use docker --debug to expand):
 - RedundantTargetPlatform: Setting platform to predefined $TARGETPLATFORM in FROM is redundant as this is the default behavior (line 9)
```